### PR TITLE
Update PostgreSQLCopyHelper.cs

### DIFF
--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
@@ -37,6 +37,7 @@ namespace PostgreSQLCopyHelper
             using (var binaryCopyWriter = connection.BeginBinaryImport(GetCopyCommand()))
             {
                 WriteToStream(binaryCopyWriter, entities);
+                binaryCopyWriter.Complete();
             }
         }
 


### PR DESCRIPTION
Fixed a breaking change in Npgsql 4.0 (as per release notes at http://www.npgsql.org/doc/release-notes/4.0.html ) that requires NpgsqlBinaryImporter to be closed manually.