### PR TITLE
Bulk COPY returns rows inserted

### DIFF
--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
@@ -8,6 +8,6 @@ namespace PostgreSQLCopyHelper
 {
     public interface IPostgreSQLCopyHelper<TEntity>
     {
-        void SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities);
+        int SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities);
     }
 }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
@@ -37,12 +37,12 @@ namespace PostgreSQLCopyHelper
             Columns = new List<ColumnDefinition<TEntity>>();
         }
 
-        public void SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities)
+        public int SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities)
         {
             using (var binaryCopyWriter = connection.BeginBinaryImport(GetCopyCommand()))
             {
                 WriteToStream(binaryCopyWriter, entities);
-                binaryCopyWriter.Complete();
+                return binaryCopyWriter.Complete();
             }
         }
 


### PR DESCRIPTION
Fixes #30 . Simply adds int return type to PostgreSQLCopyHelper.SaveAll(). 

This PostgreSQLCopyHelper change depends on upstream npgsql/npgsql#2115 being merged and deployed, so that npgsql supports the Postgresql COPY return rows. 
