### PR TITLE
WIP: Bulk Copy Returns Count of Inserted Rows

### DIFF
--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/ArrayTypesTest.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/ArrayTypesTest.cs
@@ -66,12 +66,13 @@ namespace PostgreSQLCopyHelper.Test
                 Array = new[] { "A", "B" }
             };
 
-            subject.SaveAll(connection, new[] { entity0 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(1, recordsSaved);
 
             // Check if the Result is not null:
             Assert.IsNotNull(result[0][0]);

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/ArrayTypesTest.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/ArrayTypesTest.cs
@@ -311,7 +311,7 @@ namespace PostgreSQLCopyHelper.Test
             return sqlCommand.ExecuteNonQuery();
         }
 
-        private List<object[]> GetAll()
+        private IList<object[]> GetAll()
         {
             return connection.GetAll("sample", "unit_test");
         }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/BasicDataTypesTests.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/BasicDataTypesTests.cs
@@ -560,7 +560,7 @@ namespace PostgreSQLCopyHelper.Test
             return sqlCommand.ExecuteNonQuery();
         }
 
-        private List<object[]> GetAll()
+        private IList<object[]> GetAll()
         {
             return connection.GetAll("sample", "unit_test");
         }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/BasicDataTypesTests.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/BasicDataTypesTests.cs
@@ -73,12 +73,13 @@ namespace PostgreSQLCopyHelper.Test
                 SmallInt = Int16.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved);
 
             Assert.IsNotNull(result[0][0]);
             Assert.IsNotNull(result[1][0]);
@@ -90,7 +91,6 @@ namespace PostgreSQLCopyHelper.Test
         [Test]
         public void Test_NullableInteger()
         {
-
             var entity0 = new TestEntity()
             {
                 Integer = Int32.MinValue
@@ -101,12 +101,13 @@ namespace PostgreSQLCopyHelper.Test
                 Integer = Int32.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][1]);
             Assert.IsNotNull(result[1][1]);
@@ -118,7 +119,6 @@ namespace PostgreSQLCopyHelper.Test
         [Test]
         public void Test_NullableMoney()
         {
-
             var entity0 = new TestEntity()
             {
                 Money = -1234567890123.45M
@@ -129,12 +129,13 @@ namespace PostgreSQLCopyHelper.Test
                 Money = 92233720368547758.07M
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][2]);
             Assert.IsNotNull(result[1][2]);
@@ -146,7 +147,6 @@ namespace PostgreSQLCopyHelper.Test
         [Test]
         public void Test_NullableNumeric()
         {
-
             var entity0 = new TestEntity()
             {
                 Numeric = Decimal.MinValue
@@ -157,12 +157,13 @@ namespace PostgreSQLCopyHelper.Test
                 Numeric = Decimal.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.Numeric, (Decimal)result[0][9]);
             Assert.AreEqual(entity1.Numeric, (Decimal)result[1][9]);
@@ -181,12 +182,13 @@ namespace PostgreSQLCopyHelper.Test
                 BigInt = Int64.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][3]);
             Assert.IsNotNull(result[1][3]);
@@ -253,12 +255,13 @@ namespace PostgreSQLCopyHelper.Test
                 Real = Single.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][5]);
             Assert.IsNotNull(result[1][5]);
@@ -280,12 +283,13 @@ namespace PostgreSQLCopyHelper.Test
                 DoublePrecision = Double.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.DoublePrecision, (Double)result[0][6]);
             Assert.AreEqual(entity1.DoublePrecision, (Double)result[1][6]);
@@ -299,12 +303,13 @@ namespace PostgreSQLCopyHelper.Test
                 ByteArray = new byte[] { 1, 2, 3 }
             };
 
-            subject.SaveAll(connection, new[] { entity0 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(1, recordSaved);
 
             Assert.AreEqual(entity0.ByteArray[0], ((byte[])result[0][7])[0]);
             Assert.AreEqual(entity0.ByteArray[1], ((byte[])result[0][7])[1]);
@@ -324,12 +329,13 @@ namespace PostgreSQLCopyHelper.Test
                 UUID = Guid.NewGuid()
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.UUID, (Guid)result[0][8]);
             Assert.AreEqual(entity1.UUID, (Guid)result[1][8]);
@@ -348,12 +354,13 @@ namespace PostgreSQLCopyHelper.Test
                 Date = DateTime.UtcNow
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][12]);
             Assert.IsNotNull(result[1][12]);
@@ -384,12 +391,13 @@ namespace PostgreSQLCopyHelper.Test
                 IpAddress = IPAddress.Parse("1.2.3.4")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][10]);
             Assert.IsNotNull(result[1][10]);
@@ -415,12 +423,13 @@ namespace PostgreSQLCopyHelper.Test
                 MacAddress = PhysicalAddress.Parse("01-02-2B-01-02-03")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved);
 
             Assert.IsNotNull(result[0][11]);
             Assert.IsNotNull(result[1][11]);
@@ -447,12 +456,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved);
 
             Assert.AreEqual(entity0.TimeSpan, (TimeSpan)result[0][13]);
             Assert.AreEqual(entity1.TimeSpan, (TimeSpan)result[1][13]);
@@ -479,12 +489,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][14]);
             Assert.IsNotNull(result[1][14]);
@@ -518,12 +529,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][15]);
             Assert.IsNotNull(result[1][15]);

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Extensions/NpgsqlExtensions.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Extensions/NpgsqlExtensions.cs
@@ -1,27 +1,23 @@
 ﻿using Npgsql;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PostgreSQLCopyHelper.Test.Extensions
 {
     public static class NpgsqlExtensions
     {
-        public static List<object[]> GetAll(this NpgsqlConnection connection, string schema, string table)
+        public static IList<object[]> GetAll(this NpgsqlConnection connection, string schema, string table)
         {
             var sqlStatement = string.Format("SELECT * FROM {0}.{1}", schema, table);
 
             var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
 
-            List<object[]> result = new List<object[]>();
+            var result = new List<object[]>();
             using (var dataReader = sqlCommand.ExecuteReader())
             {
                 while (dataReader.Read())
                 {
                     var values = new object[dataReader.FieldCount];
-                    for (int i = 0; i < dataReader.FieldCount; i++)
+                    for (var i = 0; i < dataReader.FieldCount; i++)
                     {
                         values[i] = dataReader[i];
                     }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Issues/Issue1_QuotingTest.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Issues/Issue1_QuotingTest.cs
@@ -47,12 +47,13 @@ namespace PostgreSQLCopyHelper.Test.Issues
                 Property_Two = "Isn't it nice to write in Camel Case!"
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = connection.GetAll("sample", "\"MixedCaseEntity\"");
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved);
 
             Assert.IsNotNull(result[0][0]);
             Assert.IsNotNull(result[1][0]);

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Issues/Issue2_MixedCaseEntity_Test.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/Issues/Issue2_MixedCaseEntity_Test.cs
@@ -47,12 +47,13 @@ namespace PostgreSQLCopyHelper.Test.Issues
                 Property_Two = "Isn't it nice to write in Camel Case!"
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordsSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = connection.GetAll("sample", "\"MixedCaseEntity\"");
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved);
 
             Assert.IsNotNull(result[0][0]);
             Assert.IsNotNull(result[1][0]);

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/NullableBasicDataTypesTest.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/NullableBasicDataTypesTest.cs
@@ -993,7 +993,7 @@ namespace PostgreSQLCopyHelper.Test
             return sqlCommand.ExecuteNonQuery();
         }
 
-        private List<object[]> GetAll()
+        private IList<object[]> GetAll()
         {
             return connection.GetAll("sample", "unit_test");
         }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/NullableBasicDataTypesTest.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/NullableBasicDataTypesTest.cs
@@ -73,12 +73,13 @@ namespace PostgreSQLCopyHelper.Test
                 SmallInt = Int16.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][0]);
             Assert.IsNotNull(result[1][0]);
@@ -100,12 +101,13 @@ namespace PostgreSQLCopyHelper.Test
                 SmallInt = Int16.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 }); //Currently fails on this line
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 }); //Currently fails on this line
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][0]);
             Assert.IsNotNull(result[1][0]);
@@ -127,12 +129,13 @@ namespace PostgreSQLCopyHelper.Test
                 Integer = Int32.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][1]);
             Assert.IsNotNull(result[1][1]);
@@ -154,12 +157,13 @@ namespace PostgreSQLCopyHelper.Test
                 Integer = Int32.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][1]);
             Assert.IsNotNull(result[1][1]);
@@ -181,12 +185,13 @@ namespace PostgreSQLCopyHelper.Test
                 Money = 92233720368547758.07M
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][2]);
             Assert.IsNotNull(result[1][2]);
@@ -208,12 +213,13 @@ namespace PostgreSQLCopyHelper.Test
                 Money = 92233720368547758.07M
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][2]);
             Assert.IsNotNull(result[1][2]);
@@ -235,12 +241,13 @@ namespace PostgreSQLCopyHelper.Test
                 Numeric = Decimal.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.Numeric, (Decimal)result[0][9]);
             Assert.AreEqual(entity1.Numeric, (Decimal)result[1][9]);
@@ -259,12 +266,13 @@ namespace PostgreSQLCopyHelper.Test
                 Numeric = Decimal.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(DBNull.Value, result[0][9]);
             Assert.AreEqual(entity1.Numeric, (Decimal)result[1][9]);
@@ -283,12 +291,13 @@ namespace PostgreSQLCopyHelper.Test
                 BigInt = Int64.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][3]);
             Assert.IsNotNull(result[1][3]);
@@ -310,12 +319,13 @@ namespace PostgreSQLCopyHelper.Test
                 BigInt = Int64.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][3]);
             Assert.IsNotNull(result[1][3]);
@@ -339,12 +349,13 @@ namespace PostgreSQLCopyHelper.Test
                 Timestamp = dateTimeToTest.AddDays(1)
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][4]);
             Assert.IsNotNull(result[1][4]);
@@ -384,12 +395,13 @@ namespace PostgreSQLCopyHelper.Test
                 Timestamp = dateTimeToTest.AddDays(1)
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][4]);
             Assert.IsNotNull(result[1][4]);
@@ -419,12 +431,13 @@ namespace PostgreSQLCopyHelper.Test
                 Real = Single.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][5]);
             Assert.IsNotNull(result[1][5]);
@@ -446,12 +459,13 @@ namespace PostgreSQLCopyHelper.Test
                 Real = Single.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][5]);
             Assert.IsNotNull(result[1][5]);
@@ -473,12 +487,13 @@ namespace PostgreSQLCopyHelper.Test
                 DoublePrecision = Double.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.DoublePrecision, (Double)result[0][6]);
             Assert.AreEqual(entity1.DoublePrecision, (Double)result[1][6]);
@@ -497,12 +512,13 @@ namespace PostgreSQLCopyHelper.Test
                 DoublePrecision = Double.MaxValue
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(DBNull.Value, result[0][6]);
             Assert.AreEqual(entity1.DoublePrecision, (Double)result[1][6]);
@@ -516,12 +532,13 @@ namespace PostgreSQLCopyHelper.Test
                 ByteArray = new byte[] { 1, 2, 3 }
             };
 
-            subject.SaveAll(connection, new[] { entity0 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(1, recordSaved);
 
             Assert.AreEqual(entity0.ByteArray[0], ((byte[])result[0][7])[0]);
             Assert.AreEqual(entity0.ByteArray[1], ((byte[])result[0][7])[1]);
@@ -536,12 +553,13 @@ namespace PostgreSQLCopyHelper.Test
                 ByteArray = null
             };
 
-            subject.SaveAll(connection, new[] { entity0 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(1, recordSaved);
             Assert.AreEqual(DBNull.Value, result[0][7]);
         }
 
@@ -558,12 +576,13 @@ namespace PostgreSQLCopyHelper.Test
                 UUID = Guid.NewGuid()
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.UUID, (Guid)result[0][8]);
             Assert.AreEqual(entity1.UUID, (Guid)result[1][8]);
@@ -583,12 +602,13 @@ namespace PostgreSQLCopyHelper.Test
                 UUID = Guid.NewGuid()
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(DBNull.Value, result[0][8]);
             Assert.AreEqual(entity1.UUID, (Guid)result[1][8]);
@@ -607,12 +627,13 @@ namespace PostgreSQLCopyHelper.Test
                 Date = DateTime.UtcNow
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][12]);
             Assert.IsNotNull(result[1][12]);
@@ -643,12 +664,13 @@ namespace PostgreSQLCopyHelper.Test
                 Date = DateTime.UtcNow
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][12]);
             Assert.IsNotNull(result[1][12]);
@@ -676,12 +698,13 @@ namespace PostgreSQLCopyHelper.Test
                 IpAddress = IPAddress.Parse("1.2.3.4")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][10]);
             Assert.IsNotNull(result[1][10]);
@@ -706,12 +729,13 @@ namespace PostgreSQLCopyHelper.Test
                 IpAddress = IPAddress.Parse("1.2.3.4")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][10]);
             Assert.IsNotNull(result[1][10]);
@@ -735,12 +759,13 @@ namespace PostgreSQLCopyHelper.Test
                 MacAddress = PhysicalAddress.Parse("01-02-2B-01-02-03")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][11]);
             Assert.IsNotNull(result[1][11]);
@@ -765,12 +790,13 @@ namespace PostgreSQLCopyHelper.Test
                 MacAddress = PhysicalAddress.Parse("01-02-2B-01-02-03")
             };
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][11]);
             Assert.IsNotNull(result[1][11]);
@@ -795,12 +821,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(entity0.TimeSpan, (TimeSpan)result[0][13]);
             Assert.AreEqual(entity1.TimeSpan, (TimeSpan)result[1][13]);
@@ -820,12 +847,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.AreEqual(DBNull.Value, result[0][13]);
             Assert.AreEqual(entity1.TimeSpan, (TimeSpan)result[1][13]);
@@ -852,12 +880,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][14]);
             Assert.IsNotNull(result[1][14]);
@@ -886,12 +915,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][14]);
             Assert.IsNotNull(result[1][14]);
@@ -923,12 +953,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][15]);
             Assert.IsNotNull(result[1][15]);
@@ -953,12 +984,13 @@ namespace PostgreSQLCopyHelper.Test
             };
 
 
-            subject.SaveAll(connection, new[] { entity0, entity1 });
+            var recordSaved = subject.SaveAll(connection, new[] { entity0, entity1 });
 
             var result = GetAll();
 
             // Check if we have the amount of rows:
             Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordSaved);
 
             Assert.IsNotNull(result[0][15]);
             Assert.IsNotNull(result[1][15]);

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Npgsql" Version="4.1.0-ci.1320" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Npgsql" Version="4.0.0" />
+    <PackageReference Include="Npgsql" Version="4.1.0-ci.1320" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
@@ -8,6 +8,6 @@ namespace PostgreSQLCopyHelper
 {
     public interface IPostgreSQLCopyHelper<TEntity>
     {
-        void SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities);
+        ulong SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities);
     }
 }

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
@@ -37,12 +37,12 @@ namespace PostgreSQLCopyHelper
             Columns = new List<ColumnDefinition<TEntity>>();
         }
 
-        public void SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities)
+        public ulong SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities)
         {
             using (var binaryCopyWriter = connection.BeginBinaryImport(GetCopyCommand()))
             {
                 WriteToStream(binaryCopyWriter, entities);
-                binaryCopyWriter.Complete();
+                return binaryCopyWriter.Complete();
             }
         }
 

--- a/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.csproj
+++ b/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper/PostgreSQLCopyHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Authors>Philipp Wagner</Authors>
     <Company />
     <Product />
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="4.0.0" />
+    <PackageReference Include="Npgsql" Version="4.1.0-ci.1320" />
   </ItemGroup>
 
 


### PR DESCRIPTION
**Core Work to Support Feature:**
- [x] Upgrade to [Unstable Ngpsql](https://www.myget.org/feed/npgsql-unstable/package/nuget/Npgsql) (Version 4.1.0-ci.1320) with supporting PR (https://github.com/npgsql/npgsql/pull/2150)
- [x] Add unit tests around return of inserted row count

**Remaining Work**
- [ ] ~Depending on if supporting PR (https://github.com/npgsql/npgsql/pull/2150) makes it in to `Npgsql 4.0.4` or not, re-add support for `net45` and `net451`~
   - ~We could still drop `net45` and `net451` if it doesn't make it into  `Npgsql 4.0.4`, @bytefish's decision~
- [ ] Upgrade to released stable version of Ngpsql with supporting PR when available

**Misc Cleanup:**
- [x] Upgrade to Test Project to NetCoreApp 2.1
- [x] Upgrade Microsoft.NET.Test.Sdk to latest stable (Version 15.8.0)
- [x] Small clean up of `NpgsqlExtensions.cs`