### PR TITLE
Support Async Enumerables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG #
 
+## 2.6.0 ##
+
+* [See Changes](https://github.com/bytefish/PostgreSQLCopyHelper/compare/2.5.1...2.6.0)
+
+#### This release: 
+- Exposes ability to use IAsyncEnumerable
+- Better support when cancelling `SaveAllAsync`
 
 ## 2.5.1 ##
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ private async Task<ulong> WriteToDatabaseAsync(PostgreSQLCopyHelper<TestEntity> 
 }
 ```
 
+Or asynchronously with asynchronous enumerables:
+
+```csharp
+private async Task<ulong> WriteToDatabaseAsync(PostgreSQLCopyHelper<TestEntity> copyHelper, IAsyncEnumerable<TestEntity> entities, CancellationToken cancellationToken = default)
+{
+    using (var connection = new NpgsqlConnection("Server=127.0.0.1;Port=5432;Database=sampledb;User Id=philipp;Password=test_pwd;"))
+    {
+        await connection.OpenAsync(cancellationToken);
+
+        // Returns count of rows written 
+        return await copyHelper.SaveAllAsync(connection, entities, cancellationToken);
+    }
+}
+```
+
 ## Case-Sensitive Identifiers ##
 
 By default the library does not apply quotes to identifiers, such as Table Names and Column Names. If you want PostgreSQL-conform quoting for identifiers, 

--- a/src/PostgreSQLCopyHelper.Test/Issues/Issue56_AsyncEnumerable_Test.cs
+++ b/src/PostgreSQLCopyHelper.Test/Issues/Issue56_AsyncEnumerable_Test.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Npgsql;
+using NUnit.Framework;
+using PostgreSQLCopyHelper.Test.Extensions;
+
+namespace PostgreSQLCopyHelper.Test.Issues
+{
+    [TestFixture]
+    [Description("A Unit Test to see, if PostgreSQLCopyHelper works with AsyncEnumerable.")]
+    public class Issue56_AsyncEnumerable_Test : TransactionalTestBase
+    {
+        private class User
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        private PostgreSQLCopyHelper<User> subject;
+
+        protected override void OnSetupInTransaction()
+        {
+            CreateTable();
+        }
+
+        [Test]
+        public async Task Test_AsyncEnumerable_BulkInsert()
+        {
+            subject = new PostgreSQLCopyHelper<User>("sample", "TestUsers")
+                     .MapInteger("Id", x => x.Id)
+                     .MapText("Name", x => x.Name);
+
+            var recordsSaved = new List<User>();
+
+            await foreach (var user in FetchUserData())
+            {
+                recordsSaved.Add(user);
+            }
+
+            // Try to work with the Bulk Inserter:
+            await subject.SaveAllAsync(connection, FetchUserData());
+
+            var result = connection.GetAll("sample", "TestUsers");
+
+            // Check if we have the amount of rows:
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2, recordsSaved.Count);
+
+            Assert.IsNotNull(result[0][0]);
+            Assert.IsNotNull(result[1][0]);
+
+            Assert.AreEqual(recordsSaved[0].Id, (int) result[0][0]);
+            Assert.AreEqual(recordsSaved[0].Name, (string) result[0][1]);
+
+            Assert.AreEqual(recordsSaved[1].Id, (int) result[1][0]);
+            Assert.AreEqual(recordsSaved[1].Name, (string) result[1][1]);
+        }
+
+        private static async IAsyncEnumerable<User> FetchUserData()
+        {
+            for (var i = 1; i <= 2; i++)
+            {
+                // Simulate waiting for data to come through.
+                await Task.Delay(10);
+                yield return new User
+                {
+                    Id = i,
+                    Name = $"Username {i}"
+                };
+            }
+        }
+
+        private int CreateTable()
+        {
+            var sqlStatement = @"CREATE TABLE sample.TestUsers
+                                (
+                                    Id integer,
+                                    Name text                
+                                 );";
+
+            var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
+
+            return sqlCommand.ExecuteNonQuery();
+        }
+    }
+}

--- a/src/PostgreSQLCopyHelper.Test/Issues/Issue58_CancelRequest_Test.cs
+++ b/src/PostgreSQLCopyHelper.Test/Issues/Issue58_CancelRequest_Test.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NUnit.Framework;
+
+namespace PostgreSQLCopyHelper.Test.Issues
+{
+    [TestFixture]
+    [Description("A Unit Test to see, if PostgreSQLCopyHelper works with Canceling Requests.")]
+    public class Issue58_CancelRequest_Test : TransactionalTestBase
+    {
+        private class User
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        private PostgreSQLCopyHelper<User> subject;
+
+        protected override void OnSetupInTransaction()
+        {
+            CreateTable();
+        }
+
+        [Test]
+        public async Task Test_CanceledBulkInsertThrowsWhenCanceled()
+        {
+            subject = new PostgreSQLCopyHelper<User>("sample", "TestUsers")
+                     .MapInteger("Id", x => x.Id)
+                     .MapText("Name", x => x.Name);
+
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            // Try to work with the Bulk Inserter:
+            try
+            {
+                cancellationTokenSource.CancelAfter(15);
+                await subject.SaveAllAsync(connection, FetchUserData(), cancellationTokenSource.Token);
+                Assert.Fail("Should Never Reach Here!");
+            }
+            catch (TaskCanceledException)
+            {
+            }
+            catch (Exception)
+            {
+                Assert.Fail("Should Throw Exception of Type TaskCanceledException!");
+            }
+            finally
+            {
+                cancellationTokenSource.Dispose();
+            }
+        }
+
+        private static async IAsyncEnumerable<User> FetchUserData()
+        {
+            for (var i = 1; i <= 2; i++)
+            {
+                // Simulate waiting for data to come through.
+                await Task.Delay(10);
+                yield return new User
+                {
+                    Id = i,
+                    Name = $"Username {i}"
+                };
+            }
+        }
+
+        private int CreateTable()
+        {
+            var sqlStatement = @"CREATE TABLE sample.TestUsers
+                                (
+                                    Id integer,
+                                    Name text                
+                                 );";
+
+            var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
+
+            return sqlCommand.ExecuteNonQuery();
+        }
+    }
+
+}

--- a/src/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
+++ b/src/PostgreSQLCopyHelper.Test/PostgreSQLCopyHelper.Test.csproj
@@ -15,8 +15,4 @@
     <ProjectReference Include="..\PostgreSQLCopyHelper\PostgreSQLCopyHelper.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/src/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
+++ b/src/PostgreSQLCopyHelper/IPostgreSQLCopyHelper.cs
@@ -11,5 +11,6 @@ namespace PostgreSQLCopyHelper
     {
         ulong SaveAll(NpgsqlConnection connection, IEnumerable<TEntity> entities);
         ValueTask<ulong> SaveAllAsync(NpgsqlConnection connection, IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+        ValueTask<ulong> SaveAllAsync(NpgsqlConnection connection, IAsyncEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
     }
 }

--- a/src/PostgreSQLCopyHelper/Model/ColumnDefinition.cs
+++ b/src/PostgreSQLCopyHelper/Model/ColumnDefinition.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 
@@ -10,11 +11,11 @@ namespace PostgreSQLCopyHelper.Model
     {
         public string ColumnName { get; set; }
 
-        public Func<NpgsqlBinaryImporter, TEntity, Task> Write { get; set; }
+        public Func<NpgsqlBinaryImporter, TEntity, CancellationToken, Task> WriteAsync { get; set; }
 
         public override string ToString()
         {
-            return $"ColumnDefinition (ColumnName = {ColumnName}, Serialize = {Write})";
+            return $"ColumnDefinition (ColumnName = {ColumnName}, Serialize = {WriteAsync})";
         }
     }
 }

--- a/src/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
+++ b/src/PostgreSQLCopyHelper/PostgreSQLCopyHelper.cs
@@ -92,23 +92,23 @@ namespace PostgreSQLCopyHelper
 
         public PostgreSQLCopyHelper<TEntity> Map<TProperty>(string columnName, Func<TEntity, TProperty> propertyGetter, NpgsqlDbType type)
         {
-            return AddColumn(columnName, (writer, entity, token) => writer.WriteAsync(propertyGetter(entity), type, cancellationToken: token));
+            return AddColumn(columnName, (writer, entity, cancellationToken) => writer.WriteAsync(propertyGetter(entity), type, cancellationToken));
         }
 
         public PostgreSQLCopyHelper<TEntity> MapNullable<TProperty>(string columnName, Func<TEntity, TProperty?> propertyGetter, NpgsqlDbType type)
             where TProperty : struct
         {
-            return AddColumn(columnName, async (writer, entity, token) =>
+            return AddColumn(columnName, async (writer, entity, cancellationToken) =>
             {
                 var val = propertyGetter(entity);
 
                 if (!val.HasValue)
                 {
-                    await writer.WriteNullAsync(cancellationToken: token);
+                    await writer.WriteNullAsync(cancellationToken);
                 }
                 else
                 {
-                    await writer.WriteAsync(val.Value, type, cancellationToken: token);
+                    await writer.WriteAsync(val.Value, type, cancellationToken);
                 }
             });
         }


### PR DESCRIPTION
Closes #56 
Closes #58 

Could be refactored so that
`ValueTask<ulong> SaveAllAsync(NpgsqlConnection connection, IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);`
wraps the new method by calling `entities.ToAsyncEnumerable() `. However, more package references would be required.

TODO
- [x] Add Release Notes
- [x] Add Documentation for new public method