### PR TITLE
Composite types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
   </PropertyGroup>
   
   <!-- Language configuration -->

--- a/src/PostgreSQLCopyHelper.Test/Issues/Issue75_CompositeTypes_Test.cs
+++ b/src/PostgreSQLCopyHelper.Test/Issues/Issue75_CompositeTypes_Test.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+using NUnit.Framework;
+using PostgreSQLCopyHelper.Test.Extensions;
+
+namespace PostgreSQLCopyHelper.Test.Issues
+{
+    [TestFixture]
+    public class Issue75_CompositeTypes_Test : TransactionalTestBase
+    {
+        private class PersonType
+        {
+            [PgName("first_name")]
+            public string FirstName { get; set; }
+
+            [PgName("last_name")]
+            public string LastName { get; set; }
+
+            [PgName("birth_date")]
+            public DateTime BirthDate { get; set; }
+        }
+
+        private PostgreSQLCopyHelper<PersonType> subject;
+
+        protected override void OnSetupInTransaction()
+        {
+            DropTableAndType(connection, transaction);
+            CreateTableAndType(connection, transaction);
+        }
+
+        protected override void OnTeardownInTransaction()
+        {
+            DropTableAndType(connection, transaction);
+        }
+
+        [Test]
+        public void Test_CompositeBulkInsert()
+        {
+            connection.ReloadTypes();
+
+            connection.TypeMapper.MapComposite<PersonType>("sample.person_type");
+
+            subject = new PostgreSQLCopyHelper<PersonType>("sample", "CompositeTest")
+                     .Map("col_person", x => x);
+
+            var entities = new List<PersonType>();
+
+            entities.Add(new PersonType { FirstName = "Philipp", LastName = "Wagner", BirthDate = new DateTime(1912, 1, 11) });
+            entities.Add(new PersonType { FirstName = "Fake", LastName = "Fakerton", BirthDate = new DateTime(1987, 1, 11) });
+
+            // Try to work with the Bulk Inserter:
+            subject.SaveAll(connection, entities);
+
+            var result = connection.GetAll("sample", "CompositeTest")
+                .Select(x => (PersonType) x[0])
+                .OrderBy(x => x.FirstName)
+                .ToList();
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual("Fake", result[0].FirstName);
+            Assert.AreEqual("Fakerton", result[0].LastName);
+            Assert.AreEqual(new DateTime(1987, 1, 11), result[0].BirthDate);
+
+            Assert.AreEqual("Philipp", result[1].FirstName);
+            Assert.AreEqual("Wagner", result[1].LastName);
+            Assert.AreEqual(new DateTime(1912, 1, 11), result[1].BirthDate);
+        }
+
+        private void CreateTableAndType(NpgsqlConnection connection, NpgsqlTransaction transaction)
+        {
+            {
+                var sqlStatement = @"create type sample.person_type as
+                                (
+                                    first_name text,
+                                    last_name text,
+                                    birth_date date
+                                );";
+
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+
+                sqlCommand.ExecuteNonQuery();
+            }
+            {
+                var sqlStatement = @"CREATE TABLE sample.CompositeTest
+                                (
+                                    col_person sample.person_type                
+                                 );";
+
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+
+                sqlCommand.ExecuteNonQuery();
+            }
+        }
+
+        private void DropTableAndType(NpgsqlConnection connection, NpgsqlTransaction transaction)
+        {
+            {
+                var sqlStatement = @"DROP TABLE IF EXISTS sample.CompositeTest";
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+
+                sqlCommand.ExecuteNonQuery();
+            }
+            {
+                var sqlStatement = @"DROP TYPE IF EXISTS sample.person_type";
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+
+                sqlCommand.ExecuteNonQuery();
+            }
+
+        }
+    }
+}

--- a/src/PostgreSQLCopyHelper.Test/Issues/Issue75_CompositeTypes_Test.cs
+++ b/src/PostgreSQLCopyHelper.Test/Issues/Issue75_CompositeTypes_Test.cs
@@ -29,13 +29,13 @@ namespace PostgreSQLCopyHelper.Test.Issues
 
         protected override void OnSetupInTransaction()
         {
-            DropTableAndType(connection, transaction);
-            CreateTableAndType(connection, transaction);
+            DropTableAndType();
+            CreateTableAndType();
         }
 
         protected override void OnTeardownInTransaction()
         {
-            DropTableAndType(connection, transaction);
+            DropTableAndType();
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace PostgreSQLCopyHelper.Test.Issues
             Assert.AreEqual(new DateTime(1912, 1, 11), result[1].BirthDate);
         }
 
-        private void CreateTableAndType(NpgsqlConnection connection, NpgsqlTransaction transaction)
+        private void CreateTableAndType()
         {
             {
                 var sqlStatement = @"create type sample.person_type as
@@ -82,7 +82,7 @@ namespace PostgreSQLCopyHelper.Test.Issues
                                     birth_date date
                                 );";
 
-                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
 
                 sqlCommand.ExecuteNonQuery();
             }
@@ -92,23 +92,23 @@ namespace PostgreSQLCopyHelper.Test.Issues
                                     col_person sample.person_type                
                                  );";
 
-                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
 
                 sqlCommand.ExecuteNonQuery();
             }
         }
 
-        private void DropTableAndType(NpgsqlConnection connection, NpgsqlTransaction transaction)
+        private void DropTableAndType()
         {
             {
                 var sqlStatement = @"DROP TABLE IF EXISTS sample.CompositeTest";
-                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
 
                 sqlCommand.ExecuteNonQuery();
             }
             {
                 var sqlStatement = @"DROP TYPE IF EXISTS sample.person_type";
-                var sqlCommand = new NpgsqlCommand(sqlStatement, connection, transaction);
+                var sqlCommand = new NpgsqlCommand(sqlStatement, connection);
 
                 sqlCommand.ExecuteNonQuery();
             }

--- a/src/PostgreSQLCopyHelper.Test/TransactionalTestBase.cs
+++ b/src/PostgreSQLCopyHelper.Test/TransactionalTestBase.cs
@@ -9,7 +9,7 @@ namespace PostgreSQLCopyHelper.Test
     public abstract class TransactionalTestBase
     {
         protected NpgsqlConnection connection;
-        private NpgsqlTransaction transaction;
+        protected NpgsqlTransaction transaction;
 
         [SetUp]
         public void Setup()

--- a/src/PostgreSQLCopyHelper.Test/TransactionalTestBase.cs
+++ b/src/PostgreSQLCopyHelper.Test/TransactionalTestBase.cs
@@ -9,7 +9,7 @@ namespace PostgreSQLCopyHelper.Test
     public abstract class TransactionalTestBase
     {
         protected NpgsqlConnection connection;
-        protected NpgsqlTransaction transaction;
+        private NpgsqlTransaction transaction;
 
         [SetUp]
         public void Setup()

--- a/src/PostgreSQLCopyHelper/Model/ColumnDefinition.cs
+++ b/src/PostgreSQLCopyHelper/Model/ColumnDefinition.cs
@@ -14,7 +14,9 @@ namespace PostgreSQLCopyHelper.Model
 
         public Type ClrType { get; set; }
 
-        public NpgsqlDbType DbType { get; set; }
+        public NpgsqlDbType? DbType { get; set; }
+
+        public string DataTypeName { get; set; }
 
         public Func<NpgsqlBinaryImporter, TEntity, CancellationToken, Task> WriteAsync { get; set; }
 

--- a/src/PostgreSQLCopyHelper/Model/TargetColumn.cs
+++ b/src/PostgreSQLCopyHelper/Model/TargetColumn.cs
@@ -11,6 +11,8 @@ namespace PostgreSQLCopyHelper.Model
 
         public Type ClrType { get; internal set; } 
 
-        public NpgsqlDbType DbType { get; internal set; }
+        public NpgsqlDbType? DbType { get; internal set; }
+
+        public string DataTypeName { get; internal set; }
     }
 }


### PR DESCRIPTION
@say25 @Huai-Ming 

This PR adds Composite Type support. I needed to overload the ``Map(...)`` method, but that's it basically. In the ``ColumnDefinition`` I had to make the ``NpgsqlDbType`` optional, but I am not sure if it is really necessary (I don't think so). I also added a Unit Test to show how it works and verify the results: 

```csharp
        [Test]
        public void Test_CompositeBulkInsert()
        {
            connection.ReloadTypes();

            connection.TypeMapper.MapComposite<PersonType>("sample.person_type");

            subject = new PostgreSQLCopyHelper<PersonType>("sample", "CompositeTest")
                     .Map("col_person", x => x);

            var entities = new List<PersonType>();

            entities.Add(new PersonType { FirstName = "Philipp", LastName = "Wagner", BirthDate = new DateTime(1912, 1, 11) });
            entities.Add(new PersonType { FirstName = "Fake", LastName = "Fakerton", BirthDate = new DateTime(1987, 1, 11) });

            // Try to work with the Bulk Inserter:
            subject.SaveAll(connection, entities);

            var result = connection.GetAll("sample", "CompositeTest")
                .Select(x => (PersonType) x[0])
                .OrderBy(x => x.FirstName)
                .ToList();

            Assert.AreEqual(2, result.Count);

            Assert.AreEqual("Fake", result[0].FirstName);
            Assert.AreEqual("Fakerton", result[0].LastName);
            Assert.AreEqual(new DateTime(1987, 1, 11), result[0].BirthDate);

            Assert.AreEqual("Philipp", result[1].FirstName);
            Assert.AreEqual("Wagner", result[1].LastName);
            Assert.AreEqual(new DateTime(1912, 1, 11), result[1].BirthDate);
        }
```

@say25 I think we should release it as a 2.8.0?